### PR TITLE
fixed save of parameters in TOML file

### DIFF
--- a/resultInterface.py
+++ b/resultInterface.py
@@ -108,9 +108,9 @@ def showResults(World):
             TOMLSettings = TOMLutils.parametersToTOML(
                 FinalIndividueSettings)
             World.logger.log(TOMLSettings)
-            paramsFilename = "%s-EPOCH%i.toml" % (LOCALE.name,
+            paramsFilename = "%s-EPOCH%i" % (LOCALE.name,
                                                 LOCALE.EPOCH)
-            World.logger.saveSettings(paramsFilename, TOMLSettings)
+            World.logger.saveParameters(paramsFilename, TOMLSettings)
             print("\nRemember to check MAX and MIN values for each parameter.")
             print("\tresults may improve with extended ranges.")
             World.EvaluationStatistics.append(GlobalLogEntry)


### PR DESCRIPTION
Fix for ```AttributeError: 'Logger' object has no attribute 'saveSettings'``` and fixed double _.toml_ extension in filename (i.e. Locale5_EPOCH10.toml.toml)