### PR TITLE
Changed log directory names to use human-readable date+time values

### DIFF
--- a/evolution_generations.py
+++ b/evolution_generations.py
@@ -1,6 +1,7 @@
 #!/bin/python
 import json
 import random
+import time
 import datetime
 import sys
 
@@ -126,7 +127,7 @@ def gekko_generations(
         ds_specs['exchange'],
         ds_specs['currency'],
         ds_specs['asset'],
-        str(datetime.datetime.now())[-6:],
+        time.strftime("%Y_%m_%d-%H.%M.%S", time.gmtime()),
     )
     Logger = promoterz.logger.Logger(logfilename)
     # --PRINT RUNTIME ARGS TO LOG HEADER;


### PR DESCRIPTION
Problem:
Log file directory names for the same strategy only have a difficult to read datetime value as a distinguishing factor. The datetime value also does not allow for automatic sequential folder ordering, so as to know the most recent and the oldest runs.

Change:
Updated Log file directory naming to use readable time values for easier distinction between different GA runs for of the same Strategy . As a result, Log file directories for the same strategy will also automatically be ordered sequentially by most recently run for a specific strat(ascending).  
e.g:
```
RSI_BULL_BEAR_ADX_BB_SIDE-binance-USDT-BTC-2018-05-16_12.24.38
RSI_BULL_BEAR_ADX_BB_SIDE-binance-USDT-BTC-2018_05_16-12.28.13
RSI_BULL_BEAR_ADX_BB_SIDE-binance-USDT-BTC-2018_05_16-12.44.28
```