### PR TITLE
Fix: best parameters .toml save directory

### DIFF
--- a/promoterz/logger.py
+++ b/promoterz/logger.py
@@ -44,7 +44,7 @@ class Logger():
         df.to_csv(filename)
 
     def saveParameters(self, filename, content):
-        filename = "logs/%s.toml" % filename
+        filename = "logs/%s/%s.toml" % (self.logfilename,filename)
         File = open(filename, 'w')
         File.write(content)
         File.close()


### PR DESCRIPTION
Issue: 
.toml files for best parameters are being saved  directly into japonicus/logs directly. 20+ of these .toml files can be produced during one GA run for a strategy and can clog up _/logs_ directory

Proposed Fix:
Save _bestParmeter.toml_ in _/logs_ subdirectory for corresponding run where corresponding _.log_ and _localeX.csv_ files are currently stored
i.e
```
/logs
   / RSI_BULL_BEAR_ADX_BB_SIDE-binance-USDT-BTC-2018_05_16-13.23.10
        japonicus.log
        Locale1.csv
        Locale1-EPOCH50.toml
        Locale2.csv
        Locale2-EPOCH60.toml
```