### PR TITLE
bugfix evolution_generations.py

### DIFF
--- a/evolution_generations.py
+++ b/evolution_generations.py
@@ -6,6 +6,7 @@ import datetime
 import sys
 
 import promoterz
+import promoterz.sequence.standard_loop
 import evaluation
 
 from copy import deepcopy


### PR DESCRIPTION
Traceback (most recent call last):
  File "japonicus.py", line 175, in <module>
    launchJaponicus(parser)
  File "japonicus.py", line 160, in launchJaponicus
    EvaluationMode, settings, options, web=web_server
  File "/home/lencho/Dropbox/webstorm_projects/gekkoPC/japonicus_develop/evolution_generations.py", line 212, in gekko_generations
    loops = [promoterz.sequence.standard_loop.standard_loop(World,locale)]
AttributeError: module 'promoterz.sequence' has no attribute 'standard_loop'