### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dash==0.18.3
-deap==1.0.2
+deap==1.2.0
 Flask_Caching==1.3.2
 numpy==1.14.2
 Js2Py==0.50


### PR DESCRIPTION
Prevents the error:
"Could not find a version that satisfies the requirement deap==1.0.2 (from -r requirements.txt (line 2)) (from versions: 0.9.1, 0.9.2, 1.0.0rc3, 1.0.0, 1.0.1, 1.0.2.post2, 1.2.0, 1.2.1a0, 1.2.1a1, 1.2.1a2, 1.2.1b0, 1.2.1rc3, 1.2.1, 1.2.2)
No matching distribution found for deap==1.0.2 (from -r requirements.txt (line 2))"