### PR TITLE
Render parameters in HTML better

### DIFF
--- a/promoterz/webServer/layout.py
+++ b/promoterz/webServer/layout.py
@@ -84,4 +84,4 @@ def getEvalbreak(app):
 
 
 def getResults(app):
-    return [html.P(str(r[0]) + '\n' + r) for r in app.resultParameters]
+    return [html.Textarea(str(r[0]) + '\n' + str(r[1]), style={'width': '525', 'height': '550'}) for r in app.resultParameters]


### PR DESCRIPTION
Fixes https://github.com/Gab0/japonicus/issues/190 and https://github.com/Gab0/japonicus/issues/187

It makes the HTML output for the best parameters appear in a textarea so they show up formatted and can easily be copied from there.